### PR TITLE
Add automatic sysc-Go cloning and comprehensive installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,25 @@
 
 A screensaver for your terminal. Watches for idle activity on Wayland (or X11), then displays animations from [sysc-Go](https://github.com/Nomadcxx/sysc-Go) when you step away. Runs as a systemd service so it starts with your session.
 
-## Getting Started
+## Quick Install
 
-**Clone and install:**
+**One-line install:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Nomadcxx/sysc-walls/master/install.sh | sudo bash
+```
+
+Or **manual install:**
 ```bash
 git clone https://github.com/Nomadcxx/sysc-walls.git
 cd sysc-walls
-sudo ./installer
+go run cmd/installer/main.go
 ```
 
-The installer builds everything and sets up the systemd service.
+The installer automatically:
+- Clones the [sysc-Go](https://github.com/Nomadcxx/sysc-Go) animation library
+- Builds all binaries (daemon, display, client)
+- Installs to `/usr/local/bin`
+- Sets up the systemd user service
 
 **Test your installation first:**
 ```bash
@@ -105,6 +114,76 @@ Want to add your own animations or color schemes?
    ```
 
 The config validation will automatically show your new options in error messages and help text.
+
+## Building from Source
+
+### Requirements
+
+- **Go 1.24+** ([install](https://go.dev/doc/install))
+- **Git**
+- **Wayland development libraries** (for Wayland support):
+  ```bash
+  # Arch/Manjaro
+  sudo pacman -S wayland
+
+  # Debian/Ubuntu
+  sudo apt install libwayland-dev
+
+  # Fedora
+  sudo dnf install wayland-devel
+  ```
+- **Kitty terminal** (for the screensaver display)
+
+### Build Steps
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/Nomadcxx/sysc-walls.git
+   cd sysc-walls
+   ```
+
+2. **Clone the animation library:**
+   ```bash
+   git clone https://github.com/Nomadcxx/sysc-Go.git
+   ```
+
+3. **Build all binaries:**
+   ```bash
+   go build -o daemon ./cmd/daemon/
+   go build -o display ./cmd/display/
+   go build -o client ./cmd/client/
+   go build -o installer ./cmd/installer/
+   ```
+
+4. **Install binaries:**
+   ```bash
+   sudo cp daemon /usr/local/bin/sysc-walls-daemon
+   sudo cp display /usr/local/bin/sysc-walls-display
+   sudo cp client /usr/local/bin/sysc-walls-client
+   sudo chmod +x /usr/local/bin/sysc-walls-*
+   ```
+
+5. **Install systemd service:**
+   ```bash
+   mkdir -p ~/.config/systemd/user
+   cp systemd/sysc-walls-user.service ~/.config/systemd/user/sysc-walls.service
+   systemctl --user daemon-reload
+   systemctl --user enable sysc-walls.service
+   systemctl --user start sysc-walls.service
+   ```
+
+### Using the Installer (Recommended)
+
+The installer handles all of the above automatically:
+```bash
+go run cmd/installer/main.go
+```
+
+Or compile it first:
+```bash
+go build -o installer ./cmd/installer/
+sudo ./installer
+```
 
 ## What's Inside
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# ASCII art
+echo -e "${CYAN}"
+cat << "EOF"
+▄▀▀▀▀ █   █ ▄▀▀▀▀ ▄▀▀▀▀          ▄▀ █   █
+ ▀▀▀▄ ▀▀▀▀█  ▀▀▀▄ █     ▀▀▀▀▀  ▄▀   █ █ █
+▀▀▀▀  ▀▀▀▀▀ ▀▀▀▀   ▀▀▀▀       ▀      ▀ ▀
+EOF
+echo -e "${NC}"
+echo -e "${CYAN}Terminal Screensaver Installer${NC}"
+echo ""
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+    echo -e "${RED}Error: This script must be run as root (use sudo)${NC}"
+    exit 1
+fi
+
+# Check for required commands
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        echo -e "${RED}Error: $1 is not installed${NC}"
+        echo -e "${YELLOW}Install it with your package manager and try again${NC}"
+        exit 1
+    fi
+}
+
+echo -e "${CYAN}Checking dependencies...${NC}"
+check_command git
+check_command go
+
+# Get the actual user (when running with sudo)
+ACTUAL_USER="${SUDO_USER:-$USER}"
+ACTUAL_HOME=$(eval echo "~$ACTUAL_USER")
+
+# Create temporary directory
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+
+echo -e "${GREEN}✓${NC} Dependencies OK"
+echo ""
+
+# Clone repository
+echo -e "${CYAN}Cloning sysc-walls...${NC}"
+git clone --quiet https://github.com/Nomadcxx/sysc-walls.git
+cd sysc-walls
+echo -e "${GREEN}✓${NC} Repository cloned"
+
+# Clone sysc-Go
+echo -e "${CYAN}Cloning sysc-Go animation library...${NC}"
+git clone --quiet https://github.com/Nomadcxx/sysc-Go.git
+echo -e "${GREEN}✓${NC} Animation library cloned"
+
+# Build binaries
+echo -e "${CYAN}Building binaries...${NC}"
+go build -o daemon ./cmd/daemon/ 2>&1 | grep -v "^#" || true
+go build -o display ./cmd/display/ 2>&1 | grep -v "^#" || true
+go build -o client ./cmd/client/ 2>&1 | grep -v "^#" || true
+echo -e "${GREEN}✓${NC} Binaries built"
+
+# Install binaries
+echo -e "${CYAN}Installing to /usr/local/bin...${NC}"
+cp daemon /usr/local/bin/sysc-walls-daemon
+cp display /usr/local/bin/sysc-walls-display
+cp client /usr/local/bin/sysc-walls-client
+chmod +x /usr/local/bin/sysc-walls-daemon
+chmod +x /usr/local/bin/sysc-walls-display
+chmod +x /usr/local/bin/sysc-walls-client
+echo -e "${GREEN}✓${NC} Binaries installed"
+
+# Install systemd service
+echo -e "${CYAN}Installing systemd service...${NC}"
+SYSTEMD_DIR="$ACTUAL_HOME/.config/systemd/user"
+sudo -u "$ACTUAL_USER" mkdir -p "$SYSTEMD_DIR"
+cp systemd/sysc-walls-user.service "$SYSTEMD_DIR/sysc-walls.service"
+chown "$ACTUAL_USER:$ACTUAL_USER" "$SYSTEMD_DIR/sysc-walls.service"
+echo -e "${GREEN}✓${NC} Systemd service installed"
+
+# Cleanup
+cd /
+rm -rf "$TEMP_DIR"
+
+echo ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}Installation complete!${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo -e "${CYAN}Test your installation:${NC}"
+echo -e "  ${YELLOW}sysc-walls-daemon -test${NC}              # Quick test"
+echo -e "  ${YELLOW}sysc-walls-daemon -test -debug${NC}       # Test with diagnostics"
+echo ""
+echo -e "${CYAN}Enable and start the service:${NC}"
+echo -e "  ${YELLOW}systemctl --user daemon-reload${NC}"
+echo -e "  ${YELLOW}systemctl --user enable sysc-walls.service${NC}"
+echo -e "  ${YELLOW}systemctl --user start sysc-walls.service${NC}"
+echo ""
+echo -e "${CYAN}Configuration:${NC}"
+echo -e "  ${YELLOW}~/.config/sysc-walls/daemon.conf${NC}"
+echo ""


### PR DESCRIPTION
Installer improvements:
- Added cloneSyscGo() function that clones sysc-Go if not present
- Updates existing sysc-Go via git pull if already cloned
- Added as install task before 'Build binaries'

README updates:
- Added one-line curl install command at the top
- Added comprehensive 'Building from Source' section with:
  - System requirements (Go, Git, Wayland libs, Kitty)
  - Step-by-step build instructions
  - Manual installation steps
  - Installer usage instructions

New install script:
- Created install.sh for one-line curl | bash installation
- Handles cloning both repos, building, and installing
- Includes progress indicators and colored output
- Properly handles sudo user detection
- Cleans up temp files after installation

Fixes the sysc-Go dependency issue - no manual cloning required.