### PR TITLE
Revert fullscreen changes - use original working approach

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -335,20 +335,6 @@ func (d *Daemon) LaunchScreensaver() {
 			continue
 		}
 
-		// Wait for window to appear before fullscreening
-		time.Sleep(200 * time.Millisecond)
-
-		// Fullscreen the newly launched window (if niri compositor)
-		if niriComp, ok := comp.(*compositor.NiriCompositor); ok {
-			if err := niriComp.FullscreenFocusedWindow(); err != nil {
-				if d.debug {
-					log.Printf("Failed to fullscreen window on %s: %v", output.Name, err)
-				}
-			} else if d.debug {
-				log.Printf("Fullscreened window on %s", output.Name)
-			}
-		}
-
 		// Delay between launches
 		if i < len(outputs)-1 {
 			time.Sleep(150 * time.Millisecond)

--- a/internal/compositor/niri.go
+++ b/internal/compositor/niri.go
@@ -98,12 +98,3 @@ func (n *NiriCompositor) FocusOutput(name string) error {
 	}
 	return nil
 }
-
-// FullscreenFocusedWindow fullscreens the currently focused window
-func (n *NiriCompositor) FullscreenFocusedWindow() error {
-	cmd := exec.Command("niri", "msg", "action", "fullscreen-window")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to fullscreen focused window: %w", err)
-	}
-	return nil
-}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -432,12 +432,9 @@ func (c *Config) GetTerminalLauncher() string {
 func (c *Config) GetTerminalArgs() []string {
 	args := []string{}
 
-	// NOTE: Don't use --start-as=fullscreen for multi-monitor setups
-	// It causes niri to place windows on the originating output instead of
-	// the focused output. Launch normally, then fullscreen via niri action.
-	// if c.terminalFullscreen {
-	//     args = append(args, "--start-as=fullscreen")
-	// }
+	if c.terminalFullscreen {
+		args = append(args, "--start-as=fullscreen")
+	}
 
 	return args
 }


### PR DESCRIPTION
Reverting the niri fullscreen action changes. The original approach with --start-as=fullscreen worked perfectly in idle mode. The test mode issues were from fullscreening the wrong windows (existing terminals instead of new ones).

Back to simple approach:
- Use --start-as=fullscreen flag
- Let compositor handle window placement naturally
- No manual fullscreen action