### PR TITLE
Add per-effect datetime rendering policy and overlay fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,12 @@ min_duration = 30s    # Minimum time screensaver runs
 [animation]
 effect = matrix-art   # Which animation to show
 theme = rama          # Color scheme
+datetime = false      # Enable datetime display
 cycle = false         # Rotate through effects
+
+[datetime]
+position = bottom     # top, center, bottom
+interval = 1s         # Clock update interval
 
 [daemon]
 debug = false         # Enable detailed logging
@@ -189,7 +194,16 @@ Renders [sysc-Go](https://github.com/Nomadcxx/sysc-Go) animations in fullscreen 
 
 Optional CLI for testing. Not needed for normal operation.
 
-Config lives in `~/.config/sysc-walls/daemon.conf` (see [internal/config/](internal/config/)). Build uses [sysc-Go](https://github.com/Nomadcxx/sysc-Go) as a proper Go module dependency (v1.0.2+).
+Config lives in `~/.config/sysc-walls/daemon.conf` (see [internal/config/](internal/config/)). Build uses [sysc-Go](https://github.com/Nomadcxx/sysc-Go) as a proper Go module dependency (v1.0.3+).
+
+Datetime behavior:
+- Text-updatable effects (`fire-text`, `matrix-art`, `rain-art`, `beam-text`, `decrypt`, `pour`, `print`, `blackhole`, `ring-text`) render the clock as live text inside the effect.
+- Non-text effects keep the overlay fallback path.
+
+Display flags:
+- `-datetime`
+- `-datetime-position top|center|bottom`
+- `-datetime-interval 1s`
 
 ## Testing & Debugging
 
@@ -230,11 +244,6 @@ For detailed troubleshooting, compositor-specific setup, and common issues, see 
 - [ ] **DateTime Effects** - Render time/date as negative space with effects filling around glyphs (fire-datetime, matrix-datetime, etc.)
 - [ ] **VOID Theme** - New dark theme with deep blacks and subtle accents
 - [ ] **Better X11 Support** - Improved compatibility beyond xprintidle, multi-monitor X11, hybrid Wayland/X11
-- [ ] **Auto-Updating** - Self-updating daemon that checks for new versions and animations
-- [ ] **More Font Options** - Additional ASCII fonts for text effects (KABEL, YES styles)
-- [ ] **Effect Cycling Improvements** - Smoother transitions, configurable cycle timing
-- [ ] **Custom Animation Parameters** - Per-effect configuration (speed, density, colors)
-- [ ] **Lock Screen Integration** - Optional integration with swaylock/hyprlock
 
 Have a feature request? Open an issue on [GitHub](https://github.com/Nomadcxx/sysc-walls/issues).
 

--- a/cmd/display/main.go
+++ b/cmd/display/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Nomadcxx/sysc-walls/internal/clock"
 	"github.com/Nomadcxx/sysc-walls/internal/version"
 	"github.com/Nomadcxx/sysc-walls/pkg/utils"
+	ansiutil "github.com/charmbracelet/x/ansi"
 
 	syscGo "github.com/Nomadcxx/sysc-Go/animations"
 )
@@ -74,8 +75,109 @@ func loadTextContent(customPath string, debug bool) string {
 
 // isTextBasedEffect checks if an effect uses text content
 // Now uses sysc-Go registry instead of hardcoded list
-func isTextBasedEffect(effect string) bool{
+func isTextBasedEffect(effect string) bool {
 	return syscGo.IsTextBasedEffect(effect)
+}
+
+func normalizeDateTimePosition(position string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(position))
+	if normalized == "centre" {
+		normalized = "center"
+	}
+
+	switch normalized {
+	case "top", "center", "bottom":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid datetime position %q: must be top, center, or bottom", position)
+	}
+}
+
+func supportsNativeDateTimeEffect(effect string) bool {
+	switch effect {
+	case "matrix-art", "rain-art", "beam-text":
+		return true
+	default:
+		return false
+	}
+}
+
+func datetimeOverlayBlockedEffect(effect string) bool {
+	switch effect {
+	case "fire-text":
+		return true
+	default:
+		return false
+	}
+}
+
+func maxTrimmedWidth(lines []string) int {
+	maxWidth := 0
+	for _, line := range lines {
+		w := len([]rune(strings.TrimRight(line, " ")))
+		if w > maxWidth {
+			maxWidth = w
+		}
+	}
+	return maxWidth
+}
+
+func centerLineWithinWidth(line string, width int) string {
+	lineWidth := len([]rune(line))
+	if width <= lineWidth {
+		return line
+	}
+	padding := (width - lineWidth) / 2
+	return strings.Repeat(" ", padding) + line
+}
+
+func buildFireClockMaskLines(timeStr string) []string {
+	// Reuse the canonical block glyphs from the clock package; time-only for FireText readability.
+	return clock.RenderClock(timeStr)
+}
+
+func buildClockTextForAnimation(effectName, position string) string {
+	// Keep text stable at minute granularity for text effects that rebuild on SetText.
+	now := time.Now()
+	var lines []string
+	if effectName == "fire-text" {
+		// FireText mask clarity is better with compact numeric glyphs only.
+		timeStr := now.Format("15:04")
+		lines = buildFireClockMaskLines(timeStr)
+	} else {
+		timeStr := now.Format("3:04 PM")
+		if len(timeStr) > 1 && timeStr[0] != '1' && timeStr[1] == ':' {
+			timeStr = " " + timeStr
+		}
+		clockLines := clock.RenderClock(timeStr)
+		dateStr := strings.ToUpper(now.Format("Monday, January 2, 2006"))
+		clockWidth := maxTrimmedWidth(clockLines)
+		centeredDate := centerLineWithinWidth(dateStr, clockWidth)
+		lines = make([]string, 0, len(clockLines)+2)
+		lines = append(lines, clockLines...)
+		lines = append(lines, "", centeredDate)
+	}
+
+	block := strings.Join(lines, "\n")
+	switch position {
+	case "top":
+		return block + "\n\n\n\n"
+	case "bottom":
+		return "\n\n" + block
+	default: // center
+		return block
+	}
+}
+
+func setAnimationClockText(anim animations.Animation, effectName, position string) (bool, string) {
+	tu, ok := anim.(animations.TextUpdatable)
+	if !ok {
+		return false, ""
+	}
+
+	clockText := buildClockTextForAnimation(effectName, position)
+	tu.SetText(clockText)
+	return true, clockText
 }
 
 // dimANSIColors reduces the intensity of ANSI RGB colors by a factor
@@ -127,10 +229,46 @@ func dimLineRegion(line string, startCol, endCol int, factor float64) string {
 // overlayLine overlays overlay text onto base
 // For now, just returns overlay (base is already dimmed separately)
 func overlayLine(base, overlay string, width int) string {
-	// The overlay contains bright datetime text
-	// The base is already dimmed in the calling function
-	// Simply return the overlay which will show bright text on dimmed background
-	return overlay
+	if ansiutil.StringWidth(base) < width {
+		base += strings.Repeat(" ", width-ansiutil.StringWidth(base))
+	}
+
+	overlayPlain := []rune(ansiutil.Strip(overlay))
+	if len(overlayPlain) < width {
+		overlayPlain = append(overlayPlain, []rune(strings.Repeat(" ", width-len(overlayPlain)))...)
+	}
+	if len(overlayPlain) > width {
+		overlayPlain = overlayPlain[:width]
+	}
+
+	const brightWhite = "\x1b[38;2;255;255;255m"
+	const reset = "\x1b[0m"
+
+	var out strings.Builder
+	last := 0
+	for i := 0; i < width; {
+		for i < width && overlayPlain[i] == ' ' {
+			i++
+		}
+		if i >= width {
+			break
+		}
+
+		start := i
+		for i < width && overlayPlain[i] != ' ' {
+			i++
+		}
+		end := i
+
+		out.WriteString(ansiutil.Cut(base, last, start))
+		out.WriteString(brightWhite)
+		out.WriteString(string(overlayPlain[start:end]))
+		out.WriteString(reset)
+		last = end
+	}
+
+	out.WriteString(ansiutil.Cut(base, last, width))
+	return out.String()
 }
 
 // overlayDateTime overlays date-time on animation output
@@ -206,10 +344,7 @@ func overlayDateTime(animOutput string, width, height int, isTextBased bool, pos
 				break
 			}
 
-			// Dim the entire line where datetime will appear
-			animLines[lineIdx] = dimANSIColors(animLines[lineIdx], 0.35)
-
-			// Overlay datetime on top (character by character to preserve spacing)
+			// Overlay datetime without replacing the full line.
 			animLines[lineIdx] = overlayLine(animLines[lineIdx], dtLine, width)
 		}
 	}
@@ -225,11 +360,12 @@ func main() {
 		file             = flag.String("file", "", "Text file for text-based effects")
 		datetime         = flag.Bool("datetime", false, "Show date and time overlay")
 		datetimePosition = flag.String("datetime-position", "bottom", "Position of datetime overlay: top, center, bottom")
+		datetimeInterval = flag.Duration("datetime-interval", time.Second, "How often datetime updates (e.g. 1s, 2s)")
 		showVersion      = flag.Bool("version", false, "Show version information")
 		showVersionV     = flag.Bool("v", false, "Show version information (shorthand)")
 		debug            = flag.Bool("debug", false, "Enable debug logging")
-		noClear      = flag.Bool("no-clear", false, "Don't clear the screen before animation")
-		fullScreen   = flag.Bool("fullscreen", false, "Run in fullscreen mode")
+		noClear          = flag.Bool("no-clear", false, "Don't clear the screen before animation")
+		fullScreen       = flag.Bool("fullscreen", false, "Run in fullscreen mode")
 	)
 	flag.Parse()
 
@@ -237,6 +373,16 @@ func main() {
 	if *showVersion || *showVersionV {
 		fmt.Printf("%s\n", version.GetFullVersion())
 		os.Exit(0)
+	}
+
+	normalizedDateTimePosition, err := normalizeDateTimePosition(*datetimePosition)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if *datetimeInterval <= 0 {
+		fmt.Fprintf(os.Stderr, "Error: datetime-interval must be greater than 0, got %v\n", *datetimeInterval)
+		os.Exit(1)
 	}
 
 	// If fullscreen is requested, give terminal time to resize
@@ -259,7 +405,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Retry %d: size=%dx%d\n", i+1, width, height)
 		}
 	}
-	
+
 	if *debug {
 		fmt.Fprintf(os.Stderr, "Final terminal size: %dx%d\n", width, height)
 	}
@@ -271,13 +417,14 @@ func main() {
 	defer utils.RestoreTerminal()
 
 	// Load text content for text-based effects
+	activeEffect := *effect
 	var textContent string
-	if isTextBasedEffect(*effect) {
+	if isTextBasedEffect(activeEffect) && !(*datetime && supportsNativeDateTimeEffect(activeEffect)) {
 		textContent = loadTextContent(*file, *debug)
 	}
 
 	// Create animation based on effect
-	anim, err := animations.CreateAnimationWithText(*effect, width, height, *theme, textContent)
+	anim, err := animations.CreateAnimationWithText(activeEffect, width, height, *theme, textContent)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating animation: %v\n", err)
 		os.Exit(1)
@@ -301,14 +448,35 @@ func main() {
 
 	// Store values for use in goroutine
 	showDateTime := *datetime
-	effectName := *effect
-	isTextEffect := isTextBasedEffect(effectName)
+	if showDateTime && datetimeOverlayBlockedEffect(activeEffect) {
+		fmt.Fprintf(os.Stderr, "Warning: datetime is disabled for effect '%s'.\n", activeEffect)
+		showDateTime = false
+	}
+	datetimeViaText := showDateTime && supportsNativeDateTimeEffect(activeEffect) && animations.IsTextUpdatable(anim)
+	lastClockText := ""
+
+	var clockTicker *time.Ticker
+	var clockTickerChan <-chan time.Time
+	if datetimeViaText {
+		clockTicker = time.NewTicker(*datetimeInterval)
+		clockTickerChan = clockTicker.C
+		defer clockTicker.Stop()
+
+		_, clockText := setAnimationClockText(anim, activeEffect, normalizedDateTimePosition)
+		lastClockText = clockText
+	}
 
 	if *debug {
-		fmt.Printf("Starting animation: %s with theme %s\n", *effect, *theme)
+		fmt.Printf("Starting animation: %s with theme %s\n", activeEffect, *theme)
+		if activeEffect != *effect {
+			fmt.Printf("Requested effect: %s\n", *effect)
+		}
 		fmt.Printf("Terminal size: %dx%d\n", width, height)
 		fmt.Printf("Duration: infinite (screensaver mode)\n")
 		fmt.Printf("DateTime overlay: %v\n", showDateTime)
+		fmt.Printf("DateTime mode: %s\n", map[bool]string{true: "native-text", false: "overlay"}[datetimeViaText])
+		fmt.Printf("DateTime position: %s\n", normalizedDateTimePosition)
+		fmt.Printf("DateTime interval: %v\n", *datetimeInterval)
 	}
 
 	// Animation goroutine
@@ -328,8 +496,8 @@ func main() {
 				output := anim.Render()
 
 				// Apply datetime overlay if enabled
-				if showDateTime {
-					output = overlayDateTime(output, width, height, isTextEffect, *datetimePosition)
+				if showDateTime && !datetimeViaText {
+					output = overlayDateTime(output, width, height, false, normalizedDateTimePosition)
 				}
 
 				// Print animation
@@ -339,6 +507,12 @@ func main() {
 				fmt.Print("\033[H")
 
 				frame++
+			case <-clockTickerChan:
+				clockText := buildClockTextForAnimation(activeEffect, normalizedDateTimePosition)
+				if clockText != lastClockText {
+					setAnimationClockText(anim, activeEffect, normalizedDateTimePosition)
+					lastClockText = clockText
+				}
 			case <-c:
 				// Received interrupt or termination signal
 				if *debug {
@@ -359,6 +533,10 @@ func main() {
 						}
 						width, height = newWidth, newHeight
 						anim.Resize(width, height)
+						if datetimeViaText {
+							_, clockText := setAnimationClockText(anim, activeEffect, normalizedDateTimePosition)
+							lastClockText = clockText
+						}
 					}
 				}
 			}

--- a/docs/plans/2026-03-03-text-updatable-integration.md
+++ b/docs/plans/2026-03-03-text-updatable-integration.md
@@ -1,0 +1,326 @@
+# Plan: TextUpdatable Integration in sysc-walls
+
+> **Sub-skill**: `superpowers/writing-plans` -> `superpowers/executing-plans`
+> **Date**: 2026-03-03
+> **Branch**: `feat/text-updatable-integration` (from `master`)
+> **Upstream dependency**: sysc-Go v1.0.3 (PRs #48 + #49 merged)
+
+## Goal
+
+Wire up sysc-Go's `TextUpdatable` support so text-based effects render a live clock as animation negative space, while preserving existing overlay behavior for non-text effects.
+
+User requirements:
+- User can toggle datetime display (`animation.datetime = true/false`)
+- User can set datetime position (`datetime.position = top/center/bottom`)
+- Clock updates every 1 second by default and is configurable (`datetime.interval`)
+
+## Architecture Decision
+
+Use a local interface in `internal/animations`:
+- Add `TextUpdatable` in `internal/animations/animations.go`
+- Implement `SetText(string)` on text-capable wrappers in `internal/animations/optimized.go`
+- In display loop, type-assert against local interface (no sysc-Go interface leakage)
+
+Display behavior:
+- Text-updatable effects: update rendered text every `datetime.interval`
+- Non-text effects: keep current `overlayDateTime()` path (no behavior regression)
+
+---
+
+## Step 1: Update dependency and minimum version
+
+**Files**: `go.mod`, `internal/config/config.go`
+
+### Changes
+1. Bump `github.com/Nomadcxx/sysc-Go` from `v1.0.2` -> `v1.0.3`
+2. Change `MinimumSyscGoVersion` from `"1.0.1"` -> `"1.0.3"`
+
+### Verify
+```bash
+go build ./...
+```
+
+---
+
+## Step 2: Add TextUpdatable interface and compile-correct tests (TDD red)
+
+**Files**: `internal/animations/animations.go`, `internal/animations/text_updatable_test.go`
+
+### Step 2a: Add interface in animations package
+
+```go
+type TextUpdatable interface {
+    SetText(text string)
+}
+
+func IsTextUpdatable(anim Animation) bool {
+    _, ok := anim.(TextUpdatable)
+    return ok
+}
+```
+
+### Step 2b: Add failing tests (must compile and fail before implementation)
+
+Create `internal/animations/text_updatable_test.go` with factory calls that handle errors correctly:
+
+```go
+func TestTextEffectsImplementTextUpdatable(t *testing.T) {
+    effects := []string{"fire-text", "matrix-art", "rain-art", "beam-text", "decrypt", "pour", "print", "blackhole", "ring-text"}
+    for _, effect := range effects {
+        t.Run(effect, func(t *testing.T) {
+            anim, err := CreateAnimationWithText(effect, 80, 24, "rama", "TEST")
+            if err != nil {
+                t.Fatalf("CreateAnimationWithText(%s) error: %v", effect, err)
+            }
+            tu, ok := anim.(TextUpdatable)
+            if !ok {
+                t.Fatalf("%s does not implement TextUpdatable", effect)
+            }
+            tu.SetText("HELLO WORLD")
+        })
+    }
+}
+
+func TestNonTextEffectsDoNotImplementTextUpdatable(t *testing.T) {
+    effects := []string{"matrix", "fire", "fireworks", "rain", "beams", "aquarium"}
+    for _, effect := range effects {
+        t.Run(effect, func(t *testing.T) {
+            anim, err := CreateAnimation(effect, 80, 24, "rama")
+            if err != nil {
+                t.Fatalf("CreateAnimation(%s) error: %v", effect, err)
+            }
+            if _, ok := anim.(TextUpdatable); ok {
+                t.Fatalf("%s should not implement TextUpdatable", effect)
+            }
+        })
+    }
+}
+```
+
+Add a resize-safety test to catch text rollback:
+
+```go
+func TestSetTextSurvivesResizeForStatefulWrappers(t *testing.T) {
+    anim, err := CreateAnimationWithText("matrix-art", 80, 24, "rama", "INIT")
+    if err != nil {
+        t.Fatal(err)
+    }
+    tu := anim.(TextUpdatable)
+    tu.SetText("UPDATED")
+    anim.Resize(100, 30)
+
+    m, ok := anim.(*optimizedMatrixArt)
+    if !ok {
+        t.Fatalf("expected *optimizedMatrixArt, got %T", anim)
+    }
+    if m.text != "UPDATED" {
+        t.Fatalf("text state not updated, got %q", m.text)
+    }
+}
+```
+
+### Run (expect failures before Step 3)
+```bash
+go test -v ./internal/animations/ -run TextUpdatable
+go test -v ./internal/animations/ -run TestSetTextSurvivesResizeForStatefulWrappers
+```
+
+---
+
+## Step 3: Implement SetText on wrappers (green)
+
+**File**: `internal/animations/optimized.go`
+
+### Changes
+1. Add `SetText(string)` to all text-capable wrappers.
+2. For wrappers that store `text` and rebuild effect on resize, update both state and inner effect.
+
+Required state updates:
+- `optimizedBeamText`
+- `optimizedMatrixArt`
+- `optimizedRainArt`
+- `optimizedBlackhole`
+- `optimizedRingText`
+
+Example pattern for stateful wrappers:
+
+```go
+func (m *optimizedMatrixArt) SetText(text string) {
+    m.text = text
+    m.effect.SetText(text)
+}
+```
+
+Example pattern for stateless wrappers:
+
+```go
+func (f *optimizedFireText) SetText(text string) { f.effect.SetText(text) }
+```
+
+### Run
+```bash
+go test -v ./internal/animations/ -run TextUpdatable
+go test -v ./internal/animations/ -run TestSetTextSurvivesResizeForStatefulWrappers
+```
+
+Expected: pass.
+
+---
+
+## Step 4: Wire display loop without regressing non-text datetime
+
+**File**: `cmd/display/main.go`
+
+### Step 4a: Add datetime interval flag
+
+Add:
+- `-datetime-interval` (default `1s`) using `flag.Duration`
+- Validation: `> 0`, otherwise exit with clear error
+
+### Step 4b: Add helper to push clock text into TextUpdatable animation
+
+Add helper like:
+
+```go
+func setAnimationClockText(anim animations.Animation, position string, width, height int) bool
+```
+
+Behavior:
+- Type-assert `anim.(animations.TextUpdatable)`
+- Build clock text from `clock.GetDateTime()` + `clock.RenderClock()`
+- Apply vertical placement (`top`/`center`/`bottom`) by adding newline padding before/after clock block relative to terminal height
+- `SetText(clockText)`
+- Return `true` if applied, else `false`
+
+### Step 4c: Runtime flow
+
+- Keep existing render ticker (`50ms`)
+- Add `clockTicker := time.NewTicker(*datetimeInterval)`
+- On startup: if `--datetime`, call `setAnimationClockText(...)` once so first frame is populated
+- On `clockTicker`: refresh clock text for text-updatable animations
+- On `SIGWINCH`: after `anim.Resize(...)`, refresh clock text immediately when datetime enabled
+
+### Step 4d: Preserve overlay fallback for non-text effects
+
+Do **not** remove `overlayDateTime()` in this change.
+- If animation is not `TextUpdatable`, continue applying `overlayDateTime(...)` in render path
+- This avoids removing existing datetime capability for non-text effects
+
+### Manual verification
+```bash
+go build -o bin/sysc-walls-display ./cmd/display/
+./bin/sysc-walls-display -effect fire-text -theme rama -datetime -datetime-position top -datetime-interval 1s
+./bin/sysc-walls-display -effect matrix -theme rama -datetime -datetime-position bottom -datetime-interval 1s
+```
+
+Expected:
+- `fire-text`: live clock in animation text region, updates every second
+- `matrix`: existing overlay behavior still works
+
+---
+
+## Step 5: Config and command wiring
+
+**Files**: `internal/config/config.go`, `internal/config/config_test.go`
+
+### Step 5a: Add interval to config model
+
+Add field in `Config`:
+- `datetimeInterval time.Duration` (default `1 * time.Second`)
+
+Add parser key:
+- `datetime.interval` via `parseDuration`
+- Require `> 0`, else warn and keep default
+
+Add getter:
+- `GetDatetimeInterval() time.Duration`
+
+### Step 5b: Ensure default and saved config include datetime settings
+
+In both `createDefaultConfig()` and `SaveToFile()` write:
+
+```ini
+[animation]
+datetime = false
+
+[datetime]
+position = bottom
+interval = 1s
+```
+
+### Step 5c: Update `GetScreensaverCommand()` behavior
+
+If datetime enabled:
+- always append `--datetime`
+- append `--datetime-position <value>`
+- append `--datetime-interval <duration>`
+
+Remove old compatibility gate that disabled datetime on text-based effects.
+
+### Step 5d: Tests
+
+Add/adjust tests for:
+- parsing `datetime.position` and `datetime.interval`
+- invalid interval fallback (`0s`, negative, malformed)
+- saved config contains `[datetime]` section and `animation.datetime`
+- command generation includes datetime flags for both text and non-text effects when enabled
+
+### Run
+```bash
+go test -v ./internal/config/
+```
+
+---
+
+## Step 6: Documentation updates
+
+**Files**: `README.md`, optionally `TROUBLESHOOTING.md`
+
+Update docs for:
+- `animation.datetime`
+- `datetime.position`
+- `datetime.interval`
+- CLI flag `-datetime-interval`
+- Behavior split: text-updatable effects use animation text path; non-text effects use overlay fallback
+
+Note: commit only files relevant to this feature; do not blindly bundle unrelated untracked paths.
+
+---
+
+## Step 7: Final verification
+
+```bash
+go fmt ./...
+go vet ./...
+go test -v -count=1 ./...
+go test -race -count=1 ./...
+go build ./cmd/display/ ./cmd/daemon/ ./cmd/client/
+```
+
+Manual:
+```bash
+./bin/sysc-walls-display -effect matrix-art -theme rama -datetime -datetime-position center -datetime-interval 1s
+./bin/sysc-walls-display -effect fire -theme rama -datetime -datetime-position top -datetime-interval 2s
+```
+
+---
+
+## File Change Summary
+
+| File | Action | Step |
+|------|--------|------|
+| `go.mod` | Bump sysc-Go to v1.0.3 | 1 |
+| `internal/config/config.go` | Minimum version, datetime interval field/parser/writer/command flags | 1, 5 |
+| `internal/config/config_test.go` | Add datetime parsing and command-generation coverage | 5 |
+| `internal/animations/animations.go` | Add `TextUpdatable` + helper | 2 |
+| `internal/animations/text_updatable_test.go` | New compile-correct TDD tests | 2 |
+| `internal/animations/optimized.go` | Add `SetText`; keep state sync for resize-safe wrappers | 3 |
+| `cmd/display/main.go` | Add text-clock updater, ticker, interval flag, fallback overlay preservation | 4 |
+| `README.md` | Document datetime behavior and interval | 6 |
+
+## Execution Notes
+
+- Step 2 tests must fail before Step 3 changes (red -> green)
+- Do not remove overlay path in this PR; keep regression risk low
+- Handle resize explicitly for text-updatable mode to avoid stale placement
+- Keep commits small and bisectable

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Nomadcxx/sysc-walls
 go 1.24.2
 
 require (
-	github.com/Nomadcxx/sysc-Go v1.0.2
+	github.com/Nomadcxx/sysc-Go v1.0.3
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Nomadcxx/sysc-Go v1.0.2 h1:GMCMyui2B314sdcBOXEVlrYuNiMtJRkqe/jvIZ+YWps=
-github.com/Nomadcxx/sysc-Go v1.0.2/go.mod h1:aVjiviCJEgKIQy0AZ2uQbf+V36JG8ZQLDO4ZtZ9wcQk=
+github.com/Nomadcxx/sysc-Go v1.0.3 h1:VfT3rjhMkAgu+b/0CH+hMIdd2cJxbvYsimre1T7cLt0=
+github.com/Nomadcxx/sysc-Go v1.0.3/go.mod h1:aVjiviCJEgKIQy0AZ2uQbf+V36JG8ZQLDO4ZtZ9wcQk=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=

--- a/internal/animations/animations.go
+++ b/internal/animations/animations.go
@@ -8,6 +8,17 @@ type Animation interface {
 	Resize(width, height int)
 }
 
+// TextUpdatable allows changing animation text at runtime.
+type TextUpdatable interface {
+	SetText(text string)
+}
+
+// IsTextUpdatable checks whether an animation supports runtime text updates.
+func IsTextUpdatable(anim Animation) bool {
+	_, ok := anim.(TextUpdatable)
+	return ok
+}
+
 // CreateAnimation creates an animation using direct library integration
 func CreateAnimation(effect string, width, height int, theme string) (Animation, error) {
 	// Use optimized implementation that directly calls sysc-Go library

--- a/internal/animations/optimized.go
+++ b/internal/animations/optimized.go
@@ -42,13 +42,13 @@ func CreateOptimizedAnimationWithText(effect string, width, height int, theme st
 	case "beam-text":
 		return newOptimizedBeamText(width, height, palette, text)
 	case "decrypt":
-		return newOptimizedDecrypt(width, height, palette)
+		return newOptimizedDecrypt(width, height, palette, text)
 	case "pour":
-		return newOptimizedPour(width, height, palette)
+		return newOptimizedPour(width, height, palette, text)
 	case "aquarium":
 		return newOptimizedAquarium(width, height, palette)
 	case "print":
-		return newOptimizedPrint(width, height, palette)
+		return newOptimizedPrint(width, height, palette, text)
 	case "blackhole":
 		return newOptimizedBlackhole(width, height, palette, text)
 	case "ring-text":
@@ -61,18 +61,18 @@ func CreateOptimizedAnimationWithText(effect string, width, height int, theme st
 // getThemePalette returns color palette for theme
 func getThemePalette(theme string) []string {
 	palettes := map[string][]string{
-		"dracula":        {"#282a36", "#44475a", "#f8f8f2", "#6272a4", "#8be9fd", "#50fa7b", "#ffb86c", "#ff79c6", "#bd93f9", "#ff5555", "#f1fa8c"},
-		"gruvbox":        {"#282828", "#cc241d", "#98971a", "#d79921", "#458588", "#b16286", "#689d6a", "#a89984", "#928374", "#fb4934", "#b8bb26", "#fabd2f", "#83a598", "#d3869b", "#8ec07c", "#ebdbb2"},
-		"nord":           {"#2e3440", "#3b4252", "#434c5e", "#4c566a", "#d8dee9", "#e5e9f0", "#eceff4", "#8fbcbb", "#88c0d0", "#81a1c1", "#5e81ac", "#bf616a", "#d08770", "#ebcb8b", "#a3be8c", "#b48ead"},
-		"tokyo-night":    {"#1a1b26", "#24283b", "#414868", "#565f89", "#787c99", "#a9b1d6", "#c0caf5", "#7aa2f7", "#bb9af7", "#7dcfff", "#73daca", "#9ece6a", "#e0af68", "#f7768e", "#ff9e64", "#db4b4b"},
-		"catppuccin":     {"#1e1e2e", "#181825", "#313244", "#45475a", "#585b70", "#cdd6f4", "#f5e0dc", "#f2cdcd", "#f5c2e7", "#cba6f7", "#f38ba8", "#eba0ac", "#fab387", "#f9e2af", "#a6e3a1", "#94e2d5", "#89dceb", "#74c7ec", "#89b4fa", "#b4befe"},
-		"material":       {"#263238", "#2e3c43", "#314549", "#37474f", "#607d8b", "#546e7a", "#b0bec5", "#80cbc4", "#4dd0e1", "#4fc3f7", "#29b6f6", "#039be5", "#0288d1", "#0277bd", "#01579b"},
-		"solarized":      {"#002b36", "#073642", "#586e75", "#657b83", "#839496", "#93a1a1", "#eee8d5", "#fdf6e3", "#b58900", "#cb4b16", "#dc322f", "#d33682", "#6c71c4", "#268bd2", "#2aa198", "#859900"},
+		"dracula":         {"#282a36", "#44475a", "#f8f8f2", "#6272a4", "#8be9fd", "#50fa7b", "#ffb86c", "#ff79c6", "#bd93f9", "#ff5555", "#f1fa8c"},
+		"gruvbox":         {"#282828", "#cc241d", "#98971a", "#d79921", "#458588", "#b16286", "#689d6a", "#a89984", "#928374", "#fb4934", "#b8bb26", "#fabd2f", "#83a598", "#d3869b", "#8ec07c", "#ebdbb2"},
+		"nord":            {"#2e3440", "#3b4252", "#434c5e", "#4c566a", "#d8dee9", "#e5e9f0", "#eceff4", "#8fbcbb", "#88c0d0", "#81a1c1", "#5e81ac", "#bf616a", "#d08770", "#ebcb8b", "#a3be8c", "#b48ead"},
+		"tokyo-night":     {"#1a1b26", "#24283b", "#414868", "#565f89", "#787c99", "#a9b1d6", "#c0caf5", "#7aa2f7", "#bb9af7", "#7dcfff", "#73daca", "#9ece6a", "#e0af68", "#f7768e", "#ff9e64", "#db4b4b"},
+		"catppuccin":      {"#1e1e2e", "#181825", "#313244", "#45475a", "#585b70", "#cdd6f4", "#f5e0dc", "#f2cdcd", "#f5c2e7", "#cba6f7", "#f38ba8", "#eba0ac", "#fab387", "#f9e2af", "#a6e3a1", "#94e2d5", "#89dceb", "#74c7ec", "#89b4fa", "#b4befe"},
+		"material":        {"#263238", "#2e3c43", "#314549", "#37474f", "#607d8b", "#546e7a", "#b0bec5", "#80cbc4", "#4dd0e1", "#4fc3f7", "#29b6f6", "#039be5", "#0288d1", "#0277bd", "#01579b"},
+		"solarized":       {"#002b36", "#073642", "#586e75", "#657b83", "#839496", "#93a1a1", "#eee8d5", "#fdf6e3", "#b58900", "#cb4b16", "#dc322f", "#d33682", "#6c71c4", "#268bd2", "#2aa198", "#859900"},
 		"monochrome":      {"#000000", "#1a1a1a", "#333333", "#4d4d4d", "#666666", "#808080", "#999999", "#b3b3b3", "#cccccc", "#e6e6e6", "#ffffff"},
 		"trainsishardjob": {"#000000", "#ff00ff", "#00ffff", "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#ffffff"},
 		"rama":            {"#2b2d42", "#8d99ae", "#d90429", "#ef233c", "#edf2f4", "#ef233c", "#d90429", "#8d99ae", "#edf2f4"},
-		"eldritch":       {"#212337", "#292e42", "#7081d0", "#04d1f9", "#37f499", "#f16c75", "#a48cf2", "#f265b5", "#f7c67f", "#ebfafa"},
-		"dark":           {"#000000", "#1a1a1a", "#333333", "#4d4d4d", "#666666", "#808080", "#999999", "#b3b3b3", "#cccccc", "#e6e6e6", "#ffffff"},
+		"eldritch":        {"#212337", "#292e42", "#7081d0", "#04d1f9", "#37f499", "#f16c75", "#a48cf2", "#f265b5", "#f7c67f", "#ebfafa"},
+		"dark":            {"#000000", "#1a1a1a", "#333333", "#4d4d4d", "#666666", "#808080", "#999999", "#b3b3b3", "#cccccc", "#e6e6e6", "#ffffff"},
 	}
 
 	if palette, ok := palettes[theme]; ok {
@@ -158,6 +158,10 @@ func (f *optimizedFireText) Resize(width, height int) {
 	f.effect.Resize(width, height)
 }
 
+func (f *optimizedFireText) SetText(text string) {
+	f.effect.SetText(text)
+}
+
 // Fireworks - uses simple constructor
 type optimizedFireworks struct {
 	effect *syscGo.FireworksEffect
@@ -241,11 +245,11 @@ func (b *optimizedBeams) Resize(width, height int) {
 
 // BeamText - uses config struct with auto-sizing and centering wrapper
 type optimizedBeamText struct {
-	effect       *syscGo.BeamTextEffect
-	palette      []string
-	text         string
-	termWidth    int
-	termHeight   int
+	effect     *syscGo.BeamTextEffect
+	palette    []string
+	text       string
+	termWidth  int
+	termHeight int
 }
 
 func newOptimizedBeamText(width, height int, palette []string, text string) (*optimizedBeamText, error) {
@@ -287,21 +291,31 @@ func (b *optimizedBeamText) Resize(width, height int) {
 	b.effect = syscGo.NewBeamTextEffect(config)
 }
 
+func (b *optimizedBeamText) SetText(text string) {
+	b.text = text
+	b.effect.SetText(text)
+}
+
 // Decrypt - uses config struct
 type optimizedDecrypt struct {
 	effect  *syscGo.DecryptEffect
 	palette []string
+	text    string
 }
 
-func newOptimizedDecrypt(width, height int, palette []string) (*optimizedDecrypt, error) {
+func newOptimizedDecrypt(width, height int, palette []string, text string) (*optimizedDecrypt, error) {
 	config := syscGo.DecryptConfig{
-		Width:   width,
-		Height:  height,
-		Palette: palette,
+		Width:            width,
+		Height:           height,
+		Text:             text,
+		Palette:          palette,
+		CiphertextColors: palette,
+		TypingSpeed:      1,
 	}
 	return &optimizedDecrypt{
 		effect:  syscGo.NewDecryptEffect(config),
 		palette: palette,
+		text:    text,
 	}, nil
 }
 
@@ -315,27 +329,38 @@ func (d *optimizedDecrypt) Render() string {
 
 func (d *optimizedDecrypt) Resize(width, height int) {
 	config := syscGo.DecryptConfig{
-		Width:   width,
-		Height:  height,
-		Palette: d.palette,
+		Width:            width,
+		Height:           height,
+		Text:             d.text,
+		Palette:          d.palette,
+		CiphertextColors: d.palette,
+		TypingSpeed:      1,
 	}
 	d.effect = syscGo.NewDecryptEffect(config)
+}
+
+func (d *optimizedDecrypt) SetText(text string) {
+	d.text = text
+	d.effect.SetText(text)
 }
 
 // Pour - uses config struct
 type optimizedPour struct {
 	effect  *syscGo.PourEffect
 	palette []string
+	text    string
 }
 
-func newOptimizedPour(width, height int, palette []string) (*optimizedPour, error) {
+func newOptimizedPour(width, height int, palette []string, text string) (*optimizedPour, error) {
 	config := syscGo.PourConfig{
 		Width:  width,
 		Height: height,
+		Text:   text,
 	}
 	return &optimizedPour{
 		effect:  syscGo.NewPourEffect(config),
 		palette: palette,
+		text:    text,
 	}, nil
 }
 
@@ -351,8 +376,14 @@ func (p *optimizedPour) Resize(width, height int) {
 	config := syscGo.PourConfig{
 		Width:  width,
 		Height: height,
+		Text:   p.text,
 	}
 	p.effect = syscGo.NewPourEffect(config)
+}
+
+func (p *optimizedPour) SetText(text string) {
+	p.text = text
+	p.effect.SetText(text)
 }
 
 // Aquarium - uses config struct
@@ -430,16 +461,19 @@ func (a *optimizedAquarium) Resize(width, height int) {
 type optimizedPrint struct {
 	effect  *syscGo.PrintEffect
 	palette []string
+	text    string
 }
 
-func newOptimizedPrint(width, height int, palette []string) (*optimizedPrint, error) {
+func newOptimizedPrint(width, height int, palette []string, text string) (*optimizedPrint, error) {
 	config := syscGo.PrintConfig{
 		Width:  width,
 		Height: height,
+		Text:   text,
 	}
 	return &optimizedPrint{
 		effect:  syscGo.NewPrintEffect(config),
 		palette: palette,
+		text:    text,
 	}, nil
 }
 
@@ -455,8 +489,14 @@ func (p *optimizedPrint) Resize(width, height int) {
 	config := syscGo.PrintConfig{
 		Width:  width,
 		Height: height,
+		Text:   p.text,
 	}
 	p.effect = syscGo.NewPrintEffect(config)
+}
+
+func (p *optimizedPrint) SetText(text string) {
+	p.text = text
+	p.effect.SetText(text)
 }
 
 // MatrixArt - Matrix rain that crystallizes into ASCII art
@@ -486,6 +526,11 @@ func (m *optimizedMatrixArt) Resize(width, height int) {
 	m.effect = syscGo.NewMatrixArtEffect(width, height, m.palette, m.text)
 }
 
+func (m *optimizedMatrixArt) SetText(text string) {
+	m.text = text
+	m.effect.SetText(text)
+}
+
 // RainArt - Rain drops that freeze to form ASCII art
 type optimizedRainArt struct {
 	effect  *syscGo.RainArtEffect
@@ -511,6 +556,11 @@ func (r *optimizedRainArt) Render() string {
 
 func (r *optimizedRainArt) Resize(width, height int) {
 	r.effect = syscGo.NewRainArtEffect(width, height, r.palette, r.text)
+}
+
+func (r *optimizedRainArt) SetText(text string) {
+	r.text = text
+	r.effect.SetText(text)
 }
 
 // Blackhole - Text gets consumed by a blackhole and explodes
@@ -560,6 +610,11 @@ func (b *optimizedBlackhole) Resize(width, height int) {
 	b.effect = syscGo.NewBlackholeEffect(config)
 }
 
+func (b *optimizedBlackhole) SetText(text string) {
+	b.text = text
+	b.effect.SetText(text)
+}
+
 // RingText - Text spins on concentric rings with vortex motion
 type optimizedRingText struct {
 	effect  *syscGo.RingTextEffect
@@ -603,6 +658,11 @@ func (r *optimizedRingText) Resize(width, height int) {
 		StaticGradientDir:   syscGo.GradientHorizontal,
 	}
 	r.effect = syscGo.NewRingTextEffect(config)
+}
+
+func (r *optimizedRingText) SetText(text string) {
+	r.text = text
+	r.effect.SetText(text)
 }
 
 // stripAnsiCodes removes ANSI escape codes from a string for width calculation

--- a/internal/animations/text_updatable_test.go
+++ b/internal/animations/text_updatable_test.go
@@ -1,0 +1,89 @@
+package animations
+
+import "testing"
+
+func TestTextEffectsImplementTextUpdatable(t *testing.T) {
+	effects := []string{
+		"fire-text",
+		"matrix-art",
+		"rain-art",
+		"beam-text",
+		"decrypt",
+		"pour",
+		"print",
+		"blackhole",
+		"ring-text",
+	}
+
+	for _, effect := range effects {
+		t.Run(effect, func(t *testing.T) {
+			anim, err := CreateAnimationWithText(effect, 80, 24, "rama", "TEST")
+			if err != nil {
+				t.Fatalf("CreateAnimationWithText(%s) error: %v", effect, err)
+			}
+			tu, ok := anim.(TextUpdatable)
+			if !ok {
+				t.Fatalf("%s does not implement TextUpdatable", effect)
+			}
+
+			// Should not panic
+			tu.SetText("HELLO WORLD")
+		})
+	}
+}
+
+func TestNonTextEffectsDoNotImplementTextUpdatable(t *testing.T) {
+	effects := []string{"matrix", "fire", "fireworks", "rain", "beams", "aquarium"}
+
+	for _, effect := range effects {
+		t.Run(effect, func(t *testing.T) {
+			anim, err := CreateAnimation(effect, 80, 24, "rama")
+			if err != nil {
+				t.Fatalf("CreateAnimation(%s) error: %v", effect, err)
+			}
+			if _, ok := anim.(TextUpdatable); ok {
+				t.Fatalf("%s should not implement TextUpdatable", effect)
+			}
+		})
+	}
+}
+
+func TestIsTextUpdatable(t *testing.T) {
+	textAnim, err := CreateAnimationWithText("matrix-art", 80, 24, "rama", "TEST")
+	if err != nil {
+		t.Fatalf("CreateAnimationWithText(matrix-art) error: %v", err)
+	}
+	plainAnim, err := CreateAnimation("matrix", 80, 24, "rama")
+	if err != nil {
+		t.Fatalf("CreateAnimation(matrix) error: %v", err)
+	}
+
+	if !IsTextUpdatable(textAnim) {
+		t.Fatal("matrix-art should be TextUpdatable")
+	}
+	if IsTextUpdatable(plainAnim) {
+		t.Fatal("matrix should not be TextUpdatable")
+	}
+}
+
+func TestSetTextSurvivesResizeForStatefulWrappers(t *testing.T) {
+	anim, err := CreateAnimationWithText("matrix-art", 80, 24, "rama", "INIT")
+	if err != nil {
+		t.Fatalf("CreateAnimationWithText(matrix-art) error: %v", err)
+	}
+	tu, ok := anim.(TextUpdatable)
+	if !ok {
+		t.Fatalf("matrix-art should be TextUpdatable, got %T", anim)
+	}
+
+	tu.SetText("UPDATED")
+	anim.Resize(100, 30)
+
+	matrixArt, ok := anim.(*optimizedMatrixArt)
+	if !ok {
+		t.Fatalf("expected *optimizedMatrixArt, got %T", anim)
+	}
+	if matrixArt.text != "UPDATED" {
+		t.Fatalf("text state not updated, got %q", matrixArt.text)
+	}
+}

--- a/internal/clock/clock_test.go
+++ b/internal/clock/clock_test.go
@@ -1,0 +1,144 @@
+package clock
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderClock_OutputHeight(t *testing.T) {
+	lines := RenderClock("12:00:00 PM")
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d", len(lines))
+	}
+}
+
+func TestRenderClock_ConsistentLineWidths(t *testing.T) {
+	lines := RenderClock("12:34:56 AM")
+	if len(lines) < 2 {
+		t.Fatal("expected at least 2 lines")
+	}
+	width := len([]rune(lines[0]))
+	for i, line := range lines {
+		w := len([]rune(line))
+		if w != width {
+			t.Errorf("line %d width %d != line 0 width %d", i, w, width)
+		}
+	}
+}
+
+func TestRenderClock_AllDigitsSupported(t *testing.T) {
+	for _, ch := range "0123456789: AMP" {
+		if _, ok := clockDigits[ch]; !ok {
+			t.Errorf("missing glyph for %q", string(ch))
+		}
+	}
+}
+
+func TestRenderClock_UnknownCharFallsBackToSpace(t *testing.T) {
+	lines := RenderClock("X")
+	spaceLines := RenderClock(" ")
+	for i := range lines {
+		if lines[i] != spaceLines[i] {
+			t.Errorf("unknown char 'X' line %d: got %q, want space %q", i, lines[i], spaceLines[i])
+		}
+	}
+}
+
+func TestGetDateTime_TimeFormat(t *testing.T) {
+	timeStr, _ := GetDateTime()
+
+	if !strings.Contains(timeStr, ":") {
+		t.Errorf("time string %q missing colon", timeStr)
+	}
+	if !strings.HasSuffix(timeStr, "AM") && !strings.HasSuffix(timeStr, "PM") {
+		t.Errorf("time string %q missing AM/PM suffix", timeStr)
+	}
+}
+
+func TestGetDateTime_DateFormat(t *testing.T) {
+	_, dateStr := GetDateTime()
+
+	now := time.Now()
+	yearStr := now.Format("2006")
+	if !strings.Contains(dateStr, yearStr) {
+		t.Errorf("date string %q missing current year %s", dateStr, yearStr)
+	}
+	if dateStr != strings.ToUpper(dateStr) {
+		t.Errorf("date string %q should be all uppercase", dateStr)
+	}
+}
+
+func TestRenderDateTime_Structure(t *testing.T) {
+	lines := RenderDateTime()
+
+	if len(lines) < 5 {
+		t.Fatalf("expected at least 5 lines (3 clock + blank + date), got %d", len(lines))
+	}
+
+	for i := 0; i < 3; i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			t.Errorf("clock line %d should not be empty", i)
+		}
+	}
+
+	if strings.TrimSpace(lines[3]) != "" {
+		t.Errorf("line 3 should be blank separator, got %q", lines[3])
+	}
+
+	if strings.TrimSpace(lines[4]) == "" {
+		t.Error("date line should not be empty")
+	}
+}
+
+func TestCenterLines_Centering(t *testing.T) {
+	lines := []string{"AB", "ABCD"}
+	centered := CenterLines(lines, 10)
+
+	if !strings.HasPrefix(centered[0], "    ") {
+		t.Errorf("expected 4-space padding for 'AB' in width 10, got %q", centered[0])
+	}
+
+	if !strings.HasPrefix(centered[1], "   ") {
+		t.Errorf("expected 3-space padding for 'ABCD' in width 10, got %q", centered[1])
+	}
+}
+
+func TestCenterLines_LineWiderThanWidth(t *testing.T) {
+	lines := []string{"ABCDEFGHIJ"}
+	centered := CenterLines(lines, 5)
+
+	if centered[0] != "ABCDEFGHIJ" {
+		t.Errorf("line wider than width should be unchanged, got %q", centered[0])
+	}
+}
+
+func TestCenterLinesBright_HasANSI(t *testing.T) {
+	lines := []string{"HI"}
+	bright := CenterLinesBright(lines, 20)
+
+	if !strings.Contains(bright[0], "\x1b[38;2;255;255;255m") {
+		t.Error("expected bright white ANSI code")
+	}
+	if !strings.Contains(bright[0], "\x1b[0m") {
+		t.Error("expected ANSI reset code")
+	}
+}
+
+func TestGetMaxLineWidth(t *testing.T) {
+	tests := []struct {
+		lines    []string
+		expected int
+	}{
+		{[]string{"AB", "ABCD", "A"}, 4},
+		{[]string{""}, 0},
+		{[]string{"█▄▀"}, 3},
+	}
+
+	for _, tt := range tests {
+		got := GetMaxLineWidth(tt.lines)
+		if got != tt.expected {
+			t.Errorf("GetMaxLineWidth(%v) = %d, want %d", tt.lines, got, tt.expected)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ var AvailableEffects = syscGo.GetEffectNames()
 var AvailableThemes = syscGo.GetThemeNames()
 
 // MinimumSyscGoVersion is the minimum required version of sysc-Go
-const MinimumSyscGoVersion = "1.0.1"
+const MinimumSyscGoVersion = "1.0.3"
 
 // findDisplayBinary locates sysc-walls-display in standard locations
 func findDisplayBinary() (string, error) {
@@ -33,9 +33,9 @@ func findDisplayBinary() (string, error) {
 
 	// Fallback to common locations
 	locations := []string{
-		"/usr/bin/sysc-walls-display",           // AUR/system package
-		"/usr/local/bin/sysc-walls-display",     // Manual install
-		"./sysc-walls-display",                  // Current directory (development)
+		"/usr/bin/sysc-walls-display",       // AUR/system package
+		"/usr/local/bin/sysc-walls-display", // Manual install
+		"./sysc-walls-display",              // Current directory (development)
 	}
 
 	for _, loc := range locations {
@@ -49,18 +49,19 @@ func findDisplayBinary() (string, error) {
 
 // Config represents the daemon configuration
 type Config struct {
-	idleTimeout         time.Duration
-	minDuration         time.Duration
-	debug               bool
-	animationEffect     string
-	animationTheme      string
-	animationFile       string // Custom artwork file path for text-based effects
-	animationDatetime   bool   // Show date/time overlay (only for non-text effects)
-	datetimePosition    string // Position of datetime: "top", "center", "bottom"
-	cycleAnimations     bool
-	cycleInterval       time.Duration // How often to switch animations when cycling
-	terminalKitty       bool
-	terminalFullscreen  bool
+	idleTimeout        time.Duration
+	minDuration        time.Duration
+	debug              bool
+	animationEffect    string
+	animationTheme     string
+	animationFile      string // Custom artwork file path for text-based effects
+	animationDatetime  bool   // Show date/time display in screensaver
+	datetimePosition   string // Position of datetime: "top", "center", "bottom"
+	datetimeInterval   time.Duration
+	cycleAnimations    bool
+	cycleInterval      time.Duration // How often to switch animations when cycling
+	terminalKitty      bool
+	terminalFullscreen bool
 }
 
 // NewConfig creates a new configuration instance
@@ -71,8 +72,9 @@ func NewConfig() *Config {
 		debug:              false,
 		animationEffect:    "matrix-art",
 		animationTheme:     "rama",
-		animationDatetime:  false,    // datetime overlay disabled by default
+		animationDatetime:  false,
 		datetimePosition:   "bottom", // datetime position: top, center, or bottom
+		datetimeInterval:   1 * time.Second,
 		cycleAnimations:    false,
 		cycleInterval:      5 * time.Minute, // 5 minutes default for animation cycling
 		terminalKitty:      true,
@@ -206,6 +208,16 @@ func (c *Config) parseConfigLine(key, value string) {
 		} else {
 			fmt.Fprintf(os.Stderr, "Warning: Invalid datetime position '%s'. Must be top, center, or bottom. Using default.\n", value)
 		}
+	case "datetime.interval":
+		if duration, err := parseDuration(value); err == nil {
+			if duration > 0 {
+				c.datetimeInterval = duration
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: Invalid datetime interval '%s'. Must be > 0. Using default.\n", value)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: Invalid datetime interval '%s': %v. Using default.\n", value, err)
+		}
 	case "animation.cycle":
 		if boolVal, err := strconv.ParseBool(value); err == nil {
 			c.cycleAnimations = boolVal
@@ -321,8 +333,13 @@ func (c *Config) createDefaultConfig(configPath string) error {
 		"# Available effects: " + strings.Join(AvailableEffects, ", "),
 		fmt.Sprintf("theme = %s", c.animationTheme),
 		"# Available themes: " + strings.Join(AvailableThemes, ", "),
+		fmt.Sprintf("datetime = %t", c.animationDatetime),
 		fmt.Sprintf("cycle = %t", c.cycleAnimations),
 		fmt.Sprintf("cycle_interval = %s", formatDuration(c.cycleInterval)),
+		"",
+		"[datetime]",
+		fmt.Sprintf("position = %s", c.datetimePosition),
+		fmt.Sprintf("interval = %s", formatDuration(c.datetimeInterval)),
 		"",
 		"[terminal]",
 		fmt.Sprintf("kitty = %t", c.terminalKitty),
@@ -391,8 +408,13 @@ func (c *Config) SaveToFile(configPath string) error {
 		"# Available effects: " + strings.Join(AvailableEffects, ", "),
 		fmt.Sprintf("theme = %s", c.animationTheme),
 		"# Available themes: " + strings.Join(AvailableThemes, ", "),
+		fmt.Sprintf("datetime = %t", c.animationDatetime),
 		fmt.Sprintf("cycle = %t", c.cycleAnimations),
 		fmt.Sprintf("cycle_interval = %s", formatDuration(c.cycleInterval)),
+		"",
+		"[datetime]",
+		fmt.Sprintf("position = %s", c.datetimePosition),
+		fmt.Sprintf("interval = %s", formatDuration(c.datetimeInterval)),
 		"",
 		"[terminal]",
 		fmt.Sprintf("kitty = %t", c.terminalKitty),
@@ -472,6 +494,11 @@ func (c *Config) GetDatetimePosition() string {
 	return c.datetimePosition
 }
 
+// GetDatetimeInterval returns how often datetime should refresh.
+func (c *Config) GetDatetimeInterval() time.Duration {
+	return c.datetimeInterval
+}
+
 // SetAnimationTheme sets the animation theme with validation
 func (c *Config) SetAnimationTheme(theme string) error {
 	if !IsValidTheme(theme) {
@@ -544,6 +571,24 @@ func isSafePath(path string) bool {
 	}
 
 	return false
+}
+
+func supportsNativeDateTimeEffect(effect string) bool {
+	switch effect {
+	case "matrix-art", "rain-art", "beam-text":
+		return true
+	default:
+		return false
+	}
+}
+
+func datetimeOverlayBlockedEffect(effect string) bool {
+	switch effect {
+	case "fire-text":
+		return true
+	default:
+		return false
+	}
 }
 
 // ShouldCycleAnimations returns whether animations should be cycled
@@ -645,19 +690,16 @@ func (c *Config) GetScreensaverCommand() (string, []string, error) {
 		args = append(args, "--file", file)
 	}
 
-	// Add datetime overlay if enabled and compatible with effect
+	// Add datetime flags if enabled.
 	datetime := c.GetAnimationDatetime()
 	if datetime {
-		// Check if effect is text-based (datetime overlay is incompatible with text-based effects)
-		if syscGo.IsTextBasedEffect(effect) {
-			// Log warning but don't fail - just disable datetime for this launch
-			fmt.Fprintf(os.Stderr, "Warning: DateTime overlay disabled - incompatible with text-based effect '%s'\n", effect)
-			fmt.Fprintf(os.Stderr, "         DateTime only works with non-text effects like: matrix, fire, rain, aquarium, fireworks, beams\n")
+		if datetimeOverlayBlockedEffect(effect) {
+			fmt.Fprintf(os.Stderr, "Warning: DateTime disabled for effect '%s'\n", effect)
 		} else {
-			// Effect is compatible, add --datetime flag and position
 			args = append(args, "--datetime")
 			position := c.GetDatetimePosition()
 			args = append(args, "--datetime-position", position)
+			args = append(args, "--datetime-interval", formatDuration(c.GetDatetimeInterval()))
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -34,6 +35,18 @@ func TestNewConfig(t *testing.T) {
 
 	if cfg.GetAnimationTheme() != "rama" {
 		t.Errorf("Default theme = %s, want rama", cfg.GetAnimationTheme())
+	}
+
+	if cfg.GetAnimationDatetime() {
+		t.Error("Default datetime should be false")
+	}
+
+	if cfg.GetDatetimePosition() != "bottom" {
+		t.Errorf("Default datetime position = %s, want bottom", cfg.GetDatetimePosition())
+	}
+
+	if cfg.GetDatetimeInterval() != time.Second {
+		t.Errorf("Default datetime interval = %v, want %v", cfg.GetDatetimeInterval(), time.Second)
 	}
 
 	if cfg.ShouldCycleAnimations() != false {
@@ -190,7 +203,12 @@ debug = true
 [animation]
 effect = fire
 theme = gruvbox
+datetime = true
 cycle = false
+
+[datetime]
+position = top
+interval = 2s
 
 [terminal]
 kitty = false
@@ -223,6 +241,15 @@ fullscreen = false
 	if cfg2.GetAnimationTheme() != "gruvbox" {
 		t.Errorf("Loaded theme = %s, want gruvbox", cfg2.GetAnimationTheme())
 	}
+	if !cfg2.GetAnimationDatetime() {
+		t.Error("Loaded datetime = false, want true")
+	}
+	if cfg2.GetDatetimePosition() != "top" {
+		t.Errorf("Loaded datetime position = %s, want top", cfg2.GetDatetimePosition())
+	}
+	if cfg2.GetDatetimeInterval() != 2*time.Second {
+		t.Errorf("Loaded datetime interval = %v, want 2s", cfg2.GetDatetimeInterval())
+	}
 	if cfg2.ShouldCycleAnimations() {
 		t.Error("Loaded cycle = true, want false")
 	}
@@ -244,6 +271,9 @@ func TestSaveToFile(t *testing.T) {
 	cfg.SetDebug(true)
 	cfg.SetAnimationEffect("rain")
 	cfg.SetAnimationTheme("tokyo-night")
+	cfg.parseConfigLine("animation.datetime", "true")
+	cfg.parseConfigLine("datetime.position", "center")
+	cfg.parseConfigLine("datetime.interval", "3s")
 
 	err := cfg.SaveToFile(configPath)
 	if err != nil {
@@ -273,6 +303,15 @@ func TestSaveToFile(t *testing.T) {
 	}
 	if cfg2.GetAnimationTheme() != "tokyo-night" {
 		t.Errorf("Saved/loaded theme = %s, want tokyo-night", cfg2.GetAnimationTheme())
+	}
+	if !cfg2.GetAnimationDatetime() {
+		t.Error("Saved/loaded datetime = false, want true")
+	}
+	if cfg2.GetDatetimePosition() != "center" {
+		t.Errorf("Saved/loaded datetime position = %s, want center", cfg2.GetDatetimePosition())
+	}
+	if cfg2.GetDatetimeInterval() != 3*time.Second {
+		t.Errorf("Saved/loaded datetime interval = %v, want 3s", cfg2.GetDatetimeInterval())
 	}
 }
 
@@ -325,6 +364,19 @@ func TestGetScreensaverCommand(t *testing.T) {
 	cfg := NewConfig()
 	cfg.SetAnimationEffect("matrix")
 	cfg.SetAnimationTheme("nord")
+	cfg.parseConfigLine("animation.datetime", "true")
+	cfg.parseConfigLine("datetime.position", "top")
+	cfg.parseConfigLine("datetime.interval", "2s")
+
+	// Use a fake display binary in PATH so this test doesn't depend on host install.
+	tmpDir := t.TempDir()
+	fakeDisplay := filepath.Join(tmpDir, "sysc-walls-display")
+	if err := os.WriteFile(fakeDisplay, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("failed to write fake display binary: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
 
 	cmd := cfg.GetScreensaverCommandString()
 	if cmd == "" {
@@ -332,38 +384,99 @@ func TestGetScreensaverCommand(t *testing.T) {
 	}
 
 	// Verify it contains key components
-	if !contains(cmd, "kitty") {
+	if !strings.Contains(cmd, "kitty") {
 		t.Errorf("Command missing 'kitty': %s", cmd)
 	}
-	if !contains(cmd, "sysc-walls-display") {
+	if !strings.Contains(cmd, "sysc-walls-display") {
 		t.Errorf("Command missing 'sysc-walls-display': %s", cmd)
 	}
-	if !contains(cmd, "--effect") {
+	if !strings.Contains(cmd, "--effect") {
 		t.Errorf("Command missing '--effect': %s", cmd)
 	}
-	if !contains(cmd, "matrix") {
+	if !strings.Contains(cmd, "matrix") {
 		t.Errorf("Command missing 'matrix': %s", cmd)
 	}
-	if !contains(cmd, "--theme") {
+	if !strings.Contains(cmd, "--theme") {
 		t.Errorf("Command missing '--theme': %s", cmd)
 	}
-	if !contains(cmd, "nord") {
+	if !strings.Contains(cmd, "nord") {
 		t.Errorf("Command missing 'nord': %s", cmd)
 	}
-}
-
-// Helper function
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsMiddle(s, substr)))
-}
-
-func containsMiddle(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+	if !strings.Contains(cmd, "--datetime") {
+		t.Errorf("Command missing '--datetime': %s", cmd)
 	}
-	return false
+	if !strings.Contains(cmd, "--datetime-position top") {
+		t.Errorf("Command missing '--datetime-position top': %s", cmd)
+	}
+	if !strings.Contains(cmd, "--datetime-interval 2s") {
+		t.Errorf("Command missing '--datetime-interval 2s': %s", cmd)
+	}
+}
+
+func TestGetScreensaverCommandFireTextDisablesDatetime(t *testing.T) {
+	cfg := NewConfig()
+	cfg.SetAnimationEffect("fire-text")
+	cfg.SetAnimationTheme("nord")
+	cfg.parseConfigLine("animation.datetime", "true")
+	cfg.parseConfigLine("datetime.position", "top")
+	cfg.parseConfigLine("datetime.interval", "2s")
+
+	// Use a fake display binary in PATH so this test doesn't depend on host install.
+	tmpDir := t.TempDir()
+	fakeDisplay := filepath.Join(tmpDir, "sysc-walls-display")
+	if err := os.WriteFile(fakeDisplay, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("failed to write fake display binary: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+
+	cmd := cfg.GetScreensaverCommandString()
+	if cmd == "" {
+		t.Error("GetScreensaverCommandString() returned empty string")
+	}
+
+	if strings.Contains(cmd, "--datetime") {
+		t.Errorf("Command should not include '--datetime' for fire-text: %s", cmd)
+	}
+	if strings.Contains(cmd, "--datetime-position") {
+		t.Errorf("Command should not include '--datetime-position' for fire-text: %s", cmd)
+	}
+	if strings.Contains(cmd, "--datetime-interval") {
+		t.Errorf("Command should not include '--datetime-interval' for fire-text: %s", cmd)
+	}
+}
+
+func TestGetScreensaverCommandBeamTextAllowsDatetime(t *testing.T) {
+	cfg := NewConfig()
+	cfg.SetAnimationEffect("beam-text")
+	cfg.SetAnimationTheme("nord")
+	cfg.parseConfigLine("animation.datetime", "true")
+	cfg.parseConfigLine("datetime.position", "center")
+	cfg.parseConfigLine("datetime.interval", "2s")
+
+	tmpDir := t.TempDir()
+	fakeDisplay := filepath.Join(tmpDir, "sysc-walls-display")
+	if err := os.WriteFile(fakeDisplay, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("failed to write fake display binary: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+
+	cmd := cfg.GetScreensaverCommandString()
+	if cmd == "" {
+		t.Error("GetScreensaverCommandString() returned empty string")
+	}
+	if !strings.Contains(cmd, "--datetime") {
+		t.Errorf("Command should include '--datetime' for beam-text: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--datetime-position center") {
+		t.Errorf("Command should include '--datetime-position center' for beam-text: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--datetime-interval 2s") {
+		t.Errorf("Command should include '--datetime-interval 2s' for beam-text: %s", cmd)
+	}
 }
 
 // TestCycleInterval tests cycle interval configuration
@@ -405,6 +518,39 @@ func TestCycleInterval(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestInvalidDatetimeIntervalFallsBackToDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test.conf")
+
+	configContent := `[animation]
+effect = matrix-art
+theme = rama
+datetime = true
+
+[datetime]
+position = center
+interval = 0s
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	cfg := NewConfig()
+	if err := cfg.LoadFromFile(configPath); err != nil {
+		t.Fatalf("LoadFromFile() failed: %v", err)
+	}
+
+	if cfg.GetDatetimeInterval() != time.Second {
+		t.Errorf("datetime interval = %v, want default %v", cfg.GetDatetimeInterval(), time.Second)
+	}
+	if cfg.GetDatetimePosition() != "center" {
+		t.Errorf("datetime position = %s, want center", cfg.GetDatetimePosition())
+	}
+	if !cfg.GetAnimationDatetime() {
+		t.Error("animation.datetime should remain true")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add local `TextUpdatable` integration and wrapper `SetText` support for text-updatable effects
- add per-effect datetime policy in display/config:
  - native text datetime: `matrix-art`, `rain-art`, `beam-text`
  - overlay fallback: non-text effects (including `matrix`, `fire`, `fireworks`, `rain`, `beams`, `aquarium`) plus allowed text effects
  - explicitly disable datetime for `fire-text`
- improve overlay compositor so base ANSI colors are preserved while datetime glyphs are painted on top
- add `-datetime-interval` handling and config wiring (`datetime.interval`)
- add/expand tests for config, animation text-updatable behavior, and clock formatting

## Verification
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./cmd/display/ ./cmd/daemon/ ./cmd/client/`
