### PR TITLE
fix: reduce daemon logging spam (closes #22)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -208,9 +208,8 @@ func (d *Daemon) eventLoop() {
 			d.idleTimer.Stop()
 			d.onIdle()
 		case <-d.idleDet.Events().Resume:
-			log.Println("Daemon received resume event from channel")
 			if d.debug {
-				log.Println("Idle detector resume")
+				log.Println("Daemon received resume event from channel")
 			}
 			d.onActivity()
 		case <-d.idleTimer.C:
@@ -224,14 +223,12 @@ func (d *Daemon) eventLoop() {
 
 // onActivity handles user activity (stop screensaver, reset timer)
 func (d *Daemon) onActivity() {
-	log.Println("onActivity called - stopping screensaver")
 	if d.debug {
-		log.Println("User activity detected")
+		log.Println("User activity detected, resetting idle timer")
 	}
 
 	d.resetIdleTimer()
 	d.StopScreensaver()
-	log.Println("onActivity completed")
 }
 
 // onIdle handles idle timeout (launch screensaver)

--- a/pkg/idle/idle.go
+++ b/pkg/idle/idle.go
@@ -96,7 +96,9 @@ func (d *IdleDetector) startWaylandIdleDetection(ctx context.Context) error {
 
 	// Create Wayland idle detector
 	onIdle := func() {
-		log.Println("[Go callback] Wayland idle callback invoked")
+		if d.config.IsDebug() {
+			log.Println("[Go callback] Wayland idle callback invoked")
+		}
 		// Fire idle event
 		select {
 		case d.idleChan <- struct{}{}:
@@ -109,7 +111,9 @@ func (d *IdleDetector) startWaylandIdleDetection(ctx context.Context) error {
 	}
 
 	onResume := func() {
-		log.Println("[Go callback] Wayland resume callback invoked")
+		if d.config.IsDebug() {
+			log.Println("[Go callback] Wayland resume callback invoked")
+		}
 		d.mu.Lock()
 		d.lastActive = time.Now()
 		d.mu.Unlock()

--- a/pkg/idle/wayland.go
+++ b/pkg/idle/wayland.go
@@ -154,7 +154,6 @@ func (w *WaylandIdleDetector) registerIdleTimeout() error {
 
 	// Set handler for when system goes idle
 	notification.SetIdledHandler(func(e ext_idle_notify.IdleNotificationIdledEvent) {
-		log.Println("Wayland idle detected")
 		if w.onIdle != nil {
 			w.onIdle()
 		}
@@ -162,7 +161,6 @@ func (w *WaylandIdleDetector) registerIdleTimeout() error {
 
 	// Set handler for when system resumes from idle
 	notification.SetResumedHandler(func(e ext_idle_notify.IdleNotificationResumedEvent) {
-		log.Println("Wayland activity detected (resumed)")
 		if w.onResume != nil {
 			w.onResume()
 		}

--- a/pkg/idle/wayland_cgo.go
+++ b/pkg/idle/wayland_cgo.go
@@ -151,9 +151,9 @@ func (w *WaylandCGODetector) Start() error {
 					}
 				}
 				
-				// Heartbeat logging every 30 seconds
+				// Heartbeat logging every 5 minutes
 				pollCount++
-				if time.Since(lastHeartbeat) >= 30*time.Second {
+				if time.Since(lastHeartbeat) >= 5*time.Minute {
 					log.Printf("[Heartbeat] Wayland event loop active, polls: %d", pollCount)
 					lastHeartbeat = time.Now()
 					pollCount = 0


### PR DESCRIPTION
## Summary
- guard daemon resume/activity hot-path logs behind debug mode
- guard Wayland idle/resume callback logs behind debug mode
- reduce Wayland CGO heartbeat log cadence from 30s to 5m
- remove redundant pure-Go Wayland idle/resume handler logs

## Verification
- go vet ./cmd/daemon/
- go build ./cmd/daemon/
- go vet ./pkg/idle/
- go build ./pkg/idle/
- go vet ./...
- go build ./...
- go test ./...